### PR TITLE
DevKit init error on Japanese Windows 7

### DIFF
--- a/1-ruby-and-devkit.md
+++ b/1-ruby-and-devkit.md
@@ -9,7 +9,7 @@ Ruby is the programming language that Jekyll is written in. You'll need to insta
 
 ## Install Ruby
 
-First, click on the button below and download the installer for Ruby v2.1.0 that matches your system's architecture (x86 / x64).
+First, click on the button below and download the installer for Ruby v2.1.x that matches your system's architecture (x86 / x64).
 
 <a href="http://rubyinstaller.org/downloads/" class="button-external" target="_blank">Get Ruby for Windows</a>
 

--- a/1-ruby-and-devkit.md
+++ b/1-ruby-and-devkit.md
@@ -9,7 +9,7 @@ Ruby is the programming language that Jekyll is written in. You'll need to insta
 
 ## Install Ruby
 
-First, click on the button below and download the installer for Ruby v2.0.0 that matches your system's architecture (x86 / x64).
+First, click on the button below and download the installer for Ruby v2.1.0 that matches your system's architecture (x86 / x64).
 
 <a href="http://rubyinstaller.org/downloads/" class="button-external" target="_blank">Get Ruby for Windows</a>
 

--- a/3-syntax-highlighting.md
+++ b/3-syntax-highlighting.md
@@ -50,9 +50,24 @@ When you get to the screen below, make sure to click on the box next to *Add pyt
 
 <img alt="Screenshot from the Python installation" src="../public/img/python-path.png" class="img-nice">
 
-### Install pip
+### Install Python base of Pygments with pip
 
 Pip is a tool for installing and managing Python packages, similar to Ruby Gems. You'll need it to install Pygments, the Python package that pygments.rb uses to highlight your code.
+
+*pip.exe* should have been installed with Python (if you did use the Windows installer) in *C:/Python27/Script* and the folder added to *Path*. If it was not, see below how to install it manually.
+From the command line, run the following command to install the Python base of Pygments.
+
+~~~
+pip install Pygments
+~~~
+
+If you get something like *LookupError: unknown encoding: cp65001* run the following command first.
+
+~~~
+set PYTHONIOENCODING=utf-8
+~~~
+
+#### Install pip manually and Python base of Pygments
 
 First, click on the button below and download `get-pip.py` via the link on that site.
 
@@ -70,7 +85,7 @@ Then, run the following command to automagically download and install all requir
 python get-pip.py
 ~~~
 
-### Install Python base of Pygments
+Finally, install Python base of Pygments
 
 From the command line, run the following command to install the Python base of Pygments.
 


### PR DESCRIPTION
With Ruby v2.0.0 I get the following error:

C:\RubyDevKit>ruby dk.rb init
C:/Ruby200-x64/lib/ruby/2.0.0/win32/registry.rb:173:in `tr': invalid byte sequence in UTF-8 (ArgumentError)
        from C:/Ruby200-x64/lib/ruby/2.0.0/win32/registry.rb:173:in`initialize'
        from C:/Ruby200-x64/lib/ruby/2.0.0/win32/registry.rb:231:in `exception'
        from C:/Ruby200-x64/lib/ruby/2.0.0/win32/registry.rb:231:in`raise'
        from C:/Ruby200-x64/lib/ruby/2.0.0/win32/registry.rb:231:in `check'
        from C:/Ruby200-x64/lib/ruby/2.0.0/win32/registry.rb:254:in`OpenKey'
        from C:/Ruby200-x64/lib/ruby/2.0.0/win32/registry.rb:385:in `open'
        from C:/Ruby200-x64/lib/ruby/2.0.0/win32/registry.rb:496:in`open'
        from dk.rb:115:in `block in scan_for'
        from dk.rb:113:in`each'
        from dk.rb:113:in `scan_for'
        from dk.rb:135:in`block in installed_rubies'
        from dk.rb:135:in `collect'
        from dk.rb:135:in`installed_rubies'
        from dk.rb:143:in `init'
        from dk.rb:310:in`run'
        from dk.rb:329:in `<main>'

But it looks like it works just fine with Ruby v2.1.6

The issue was reported here as well:
http://seesaawiki.jp/w/kou1okada/d/Cygwin%20-%20Ruby-1.9.3p327%20-%20win32/registry
